### PR TITLE
Properly serialize ECONNREFUSED errors

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1,8 +1,14 @@
 const query = require('qs');
+const { Unavailable } = require('@feathersjs/errors');
+const { _ } = require('@feathersjs/commons');
 const { stripSlashes } = require('@feathersjs/commons');
 const { convert } = require('@feathersjs/errors');
 
 function toError (error) {
+  if (error.code === 'ECONNREFUSED') {
+    throw new Unavailable(error.message, _.pick(error, 'address', 'port', 'config'));
+  }
+
   throw convert(error);
 }
 

--- a/test/axios.test.js
+++ b/test/axios.test.js
@@ -77,4 +77,18 @@ describe('Axios REST connector', function () {
         assert.equal(error.code, 406);
       });
   });
+
+  it('ECONNREFUSED errors are serializable', () => {
+    const url = 'http://localhost:60000';
+    const setup = rest(url).axios(axios);
+    const app = feathers().configure(setup);
+
+    return app.service('something').find().catch(e => {
+      const err = JSON.parse(JSON.stringify(e));
+
+      assert.equal(err.name, 'Unavailable');
+      assert.equal(err.message, 'connect ECONNREFUSED 127.0.0.1:60000');
+      assert.ok(e.data.config);
+    });
+  });
 });


### PR DESCRIPTION
This is a special case and some libraries (like Axios) do include some additional information that causes a circular dependency making the error not serializable.

Closes https://github.com/feathersjs/feathers/issues/838