### PR TITLE
URL encode ID.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -25,7 +25,7 @@ class Base {
     let url = this.base;
 
     if (typeof id !== 'undefined' && id !== null) {
-      url += `/${id}`;
+      url += `/${encodeURIComponent(id)}`;
     }
 
     if (Object.keys(params).length !== 0) {


### PR DESCRIPTION
### Summary
Encode the ID in the URL.

- [x] Tell us about the problem your pull request is solving.

**Problem**
The problem arises when using

- IDs with special characters such as ä, ö, ü
- Server-to-server communication. A browser encodes those special characters automatically when part of a URL.

This is the current process:

1. A browser-based client (Google Chrome, current version) send a request to a URL like this: `PATCH http://localhost/users/123ö?param=ö333`
1.1. The browser converts the URL to `http://localhost/users/123%C3%B6?param=%C3%B6333`, see Dev Tools > Network.
1. The feathers.js app at localhost:80 routes the request to `http://localhost:2000/users/123ö?param=%C3%B6333`
1.1. The routing is done via @feathersjs/rest-client. The solutions works like the one @daffl described [here](https://github.com/feathersjs/feathers/issues/332#issuecomment-220524703) only with REST instead of Socket.io.
1.1. The app at localhost:80 decodes the URL but @feathersjs/rest-client encodes only the query string.
1. The app at localhost:2000 understands `http://localhost:2000/users/123Ã¶?param=%C3%B6333`. Business logic fails.

**Solution**
Apply "encodeURIComponent" to the ID, too.

- [ ] Are there any open issues that are related to this? No.
- [ ] Is this PR dependent on PRs in other repos? No.

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: